### PR TITLE
Downgrade `pointer_interceptor` to version `0.9.1` to avoid crash

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  pointer_interceptor: ^0.9.3+4
+  pointer_interceptor: 0.9.1
 
   debounce_throttle: ^2.0.0
 


### PR DESCRIPTION
### Issue

- https://github.com/linagora/tmail-flutter/pull/1701

