### PR TITLE
Fix for `_scrollToVisible` throwing error.

### DIFF
--- a/lib/tag_editor.dart
+++ b/lib/tag_editor.dart
@@ -715,8 +715,10 @@ class TagsEditorState<T> extends State<TagEditor<T>> {
   void _scrollToVisible() {
     Future.delayed(const Duration(milliseconds: 300), () {
       WidgetsBinding.instance.addPostFrameCallback((_) async {
-        final renderBox = context.findRenderObject() as RenderBox;
-        await Scrollable.of(context).position.ensureVisible(renderBox);
+        if (mounted) {
+          final renderBox = context.findRenderObject() as RenderBox;
+          await Scrollable.of(context).position.ensureVisible(renderBox);
+        }
       });
     });
   }


### PR DESCRIPTION
Small `mounted` check to fix `_scrollToVisible` throwing an error when I programmatically resized the screen on web (doesn't happen when manually resizing the screen).