### PR TITLE
Fixed suggestion bug in resetTextField

### DIFF
--- a/lib/tag_editor.dart
+++ b/lib/tag_editor.dart
@@ -743,6 +743,12 @@ class TagsEditorState<T> extends State<TagEditor<T>> {
     _previousText = '';
     _updateHighlight(0);
     _updateValidationSuggestionItem(null);
+    if (widget.activateSuggestionBox) {
+      // Effectively reset and trigger search for empty
+      _deBouncer?.value = '';
+      _suggestions = [];
+      _suggestionsStreamController?.add([]);
+    }
   }
 
   /// Shamelessly copied from [InputDecorator]


### PR DESCRIPTION
Typing the first character after adding a tag would sometimes fail to display suggestions.

`_deBouncer?.value = ''` ensures that any pending debounced search is cleared and a new search for an empty string is effectively triggered, properly resetting the suggestion box state for subsequent input.